### PR TITLE
Remove old plugin that breaks build

### DIFF
--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -1,7 +1,6 @@
 import routes from "./routes";
 
 export default {
-  plugins: ["~/plugins/payload-injection.js"],
   generate: {
     routes
   },


### PR DESCRIPTION
## Overview
I accidentally left a plugin in `nuxt.config.js` that I had deleted. It is no longer.