### PR TITLE
Add hsts headers with preload

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,4 @@
+[[headers]]
+  for = "/*"
+  [headers.values]
+    Strict-Transport-Security = "max-age=63072000; includeSubDomains; preload"


### PR DESCRIPTION
The preload header should force any domain under `scrambled.online` to only load with https.